### PR TITLE
Update Path to colab for usage outside Google.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ __pycache__/
 .DS_Store
 
 # Generated files
+*.DS_Store
+*.o

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ We list a few projects that use DeepLab2.
 
 ## Colab Demo
 
-* <a href='https://colab.sandbox.google.com/google-research/deeplab2/blob/main/Deeplab_Demo.ipynb'>Colab notebook for off-the-shelf inference.</a><br>
+* <a href='https://colab.research.google.com/github/google-research/deeplab2/blob/main/DeepLab_Demo.ipynb'>Colab notebook for off-the-shelf inference.</a><br>
 
 ## Change logs
 


### PR DESCRIPTION
- Update Path to colab for usage outside Google.

- Update .gitignore to account for shared objects.