### PR TITLE
Fix Decoder to work without ground-truth in the case of two frames.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,13 +5,14 @@ __pycache__/
 .vscode/
 .idea/
 .env
+.config/
 
 # Generated proto files.
 *_pb2.py
 
 # For mac
-.DS_Store
+*.DS_Store
 
 # Generated files
-*.DS_Store
 *.o
+*.so

--- a/data/data_utils.py
+++ b/data/data_utils.py
@@ -308,6 +308,7 @@ class SegmentationDecoder(object):
     if self._use_two_frames:
       return_dict['prev_image'] = self._decode_image(
           parsed_tensors, common.KEY_ENCODED_PREV_IMAGE)
-      return_dict['prev_label'] = self._decode_label(
-          parsed_tensors, common.KEY_ENCODED_PREV_LABEL)
+      if self._decode_groundtruth_label:
+        return_dict['prev_label'] = self._decode_label(
+            parsed_tensors, common.KEY_ENCODED_PREV_LABEL)
     return return_dict

--- a/data/utils/create_step_panoptic_maps.py
+++ b/data/utils/create_step_panoptic_maps.py
@@ -24,7 +24,7 @@ STEP panoptic map.
 
 To run this script, you need to install opencv-python (>=4.4.0).
 e.g. In Linux, run
-$sudo apt-get install python3-opencv
+$pip install opencv-python
 
 The input directory structure should be as follows:
 


### PR DESCRIPTION
Fix Decoder to work without ground-truth in the case of two frames.

Update .gitignore.

Update comment to recommend pip over apt-get.