### PR TITLE
Fix export: preprocess_fn returns 6 variables instead of 5

### DIFF
--- a/export_model.py
+++ b/export_model.py
@@ -126,7 +126,7 @@ class DeepLabModule(tf.Module):
       processed_image = tf.concat(
           [processed_image, processed_prev_image], axis=2)
     else:
-      (resized_image, processed_image, _, _, _) = self._preprocess_fn(
+      (resized_image, processed_image, _, _, _, _) = self._preprocess_fn(
           image=input_tensor)
 
     resized_size = tf.shape(resized_image)[0:2]

--- a/export_model.py
+++ b/export_model.py
@@ -122,7 +122,7 @@ class DeepLabModule(tf.Module):
       # frame before preprocessing, and re-assemble them.
       image, prev_image = tf.split(input_tensor, 2, axis=2)
       (resized_image, processed_image, _, processed_prev_image,
-       _) = self._preprocess_fn(image=image, prev_image=prev_image)
+       _, _) = self._preprocess_fn(image=image, prev_image=prev_image)
       processed_image = tf.concat(
           [processed_image, processed_prev_image], axis=2)
     else:


### PR DESCRIPTION
Refer to https://github.com/google-research/deeplab2/blob/main/data/preprocessing/input_preprocessing.py#L350
That method returns 6 variables.
