### PR TITLE
Update motchallenge_step.md

### DIFF
--- a/g3doc/setup/motchallenge_step.md
+++ b/g3doc/setup/motchallenge_step.md
@@ -60,10 +60,10 @@ In the following, we provide a step-by-step walk through to prepare the data.
     mkdir test/0007
 
     # Copy data.
-    cp -r MOTS/train/MOTS20-02/* train/0002/
-    cp -r MOTS/train/MOTS20-09/* train/0009/
-    cp -r MOTS/test/MOTS20-01/* test/0001/
-    cp -r MOTS/test/MOTS20-07/* test/0007/
+    cp -r MOTS/train/MOTS20-02/img1/* train/0002/
+    cp -r MOTS/train/MOTS20-09/img1/* train/0009/
+    cp -r MOTS/test/MOTS20-01/img1/* test/0001/
+    cp -r MOTS/test/MOTS20-07/img1/* test/0007/
 
     # Clean up.
     rm -r MOTS


### PR DESCRIPTION
Adapting it to the MOTChallenge dataset structure (e.g. inside MOTS20-02 there are 2 folders - img1 and gt - and 1 file -seq.init- that make the build_step_data.py script fail.