### PR TITLE
Fix layout issue by squeezing tensor.

### DIFF
--- a/model/post_processor/panoptic_deeplab.py
+++ b/model/post_processor/panoptic_deeplab.py
@@ -70,9 +70,11 @@ def _get_instance_centers_from_heatmap(
       strides=(1, 1),
       padding='valid',
       pool_mode='max')
+  pooled_center_heatmap = tf.squeeze(pooled_center_heatmap, axis=0)
+
   center_heatmap = tf.where(
       tf.equal(pooled_center_heatmap, center_heatmap), center_heatmap, 0.0)
-  center_heatmap = tf.squeeze(center_heatmap, axis=[0, 3])
+  center_heatmap = tf.squeeze(center_heatmap, axis=2)
 
   # `centers` is of shape (N, 2) with (y, x) order of the second dimension.
   centers = tf.where(tf.greater(center_heatmap, 0.0))


### PR DESCRIPTION
Fix layout issue by squeezing tensor.

As reported in multiple issues, tensorflow produced an error:
`layout failed: Invalid argument: Size of values 3 does not match size of permutation 4 @ fanning shape in ...`

This PR fixes that error. While this error did not cause issues for me during evaluation, it might have caused issues for other setups.