### PR TITLE
Add auxiliary output number as property to video models.

### DIFF
--- a/video/motion_deeplab.py
+++ b/video/motion_deeplab.py
@@ -210,7 +210,7 @@ class MotionDeepLab(tf.keras.Model):
     items = dict(encoder=self._encoder)
     items.update(self._decoder.checkpoint_items)
     return items
-  
+
   @property
   def auxiliary_output_number(self) -> int:
     # auxiliary_output_number is only supported in K-MaX meta, thus we hard

--- a/video/motion_deeplab.py
+++ b/video/motion_deeplab.py
@@ -210,3 +210,9 @@ class MotionDeepLab(tf.keras.Model):
     items = dict(encoder=self._encoder)
     items.update(self._decoder.checkpoint_items)
     return items
+  
+  @property
+  def auxiliary_output_number(self) -> int:
+    # auxiliary_output_number is only supported in K-MaX meta, thus we hard
+    # code it to 0 here.
+    return 0

--- a/video/vip_deeplab.py
+++ b/video/vip_deeplab.py
@@ -261,6 +261,12 @@ class ViPDeepLab(tf.keras.Model):
     items.update(self._decoder.checkpoint_items)
     return items
 
+  @property
+  def auxiliary_output_number(self) -> int:
+    # auxiliary_output_number is only supported in K-MaX meta, thus we hard
+    # code it to 0 here.
+    return 0
+
   def _resize_predictions(self, result_dict, target_h, target_w, reverse=False):
     """Resizes predictions to the target height and width.
 


### PR DESCRIPTION
Add auxiliary output number as property to video models.

Since the update to kMax-DeepLab, all models are required to have such property. 